### PR TITLE
Add rule regarding closing bracket on a new line

### DIFF
--- a/flake8_picky_parentheses/_redundant_parentheses.py
+++ b/flake8_picky_parentheses/_redundant_parentheses.py
@@ -49,7 +49,7 @@ class PluginRedundantParentheses:
 
     @staticmethod
     def _node_in_parens(node, parens_coords):
-        open_, _, _, close = parens_coords
+        open_, _, _, close, _ = parens_coords
         node_start = (node.lineno, node.col_offset)
         return close > node_start > open_
 
@@ -129,7 +129,7 @@ def tree_without_parens_unchanged(source_code, start_tree, parens_coords):
     Replace a pair of parentheses with a blank string and check if the
     resulting AST is still the same.
     """
-    open_, space, replacement, close = parens_coords
+    open_, space, replacement, close, _ = parens_coords
     lines = source_code.split("\n")
     lines[open_[0] - 1] = (lines[open_[0] - 1][:open_[1]]
                            + replacement

--- a/flake8_picky_parentheses/_util.py
+++ b/flake8_picky_parentheses/_util.py
@@ -1,7 +1,13 @@
+from collections import namedtuple
 import tokenize
 
 OPEN_LIST = ["[", "{", "("]
 CLOSE_LIST = ["]", "}", ")"]
+
+
+ParensCords = namedtuple("ParensCords", [
+    "open", "open_end_col", "replacement", "close", "token_indexes"
+])
 
 
 def find_parens_coords(token):
@@ -22,23 +28,24 @@ def find_parens_coords(token):
             if token[i].string in OPEN_LIST:
                 if not first_in_line:
                     opening_stack.append([token[i].start, token[i].end[1],
-                                          " ", token[i].string])
+                                          " ", token[i].string, i])
                     continue
                 if token[i + 1].start[0] == token[i].end[0]:
                     opening_stack.append([token[i].start,
                                           token[i + 1].start[1], "",
-                                          token[i].string])
+                                          token[i].string, i])
                     continue
                 # there is only this opening parenthesis on this line
                 opening_stack.append([token[i].start, len(token[i].line) - 2,
-                                      "", token[i].string])
+                                      "", token[i].string, i])
 
             if token[i].string in CLOSE_LIST:
                 opening = opening_stack.pop()
                 assert (OPEN_LIST.index(opening[3])
                         == CLOSE_LIST.index(token[i].string))
+                token_indexes = [opening[4], i]
                 parentheses_pairs.append(
-                    [*opening[0:3], token[i].start]
+                    ParensCords(*opening[0:3], token[i].start, token_indexes)
                 )
 
     return parentheses_pairs

--- a/tests/test_redundant_parentheses.py
+++ b/tests/test_redundant_parentheses.py
@@ -4,10 +4,9 @@ import sys
 import tokenize
 from typing import Set
 
-from flake8_picky_parentheses import PluginRedundantParentheses
-
-
 import pytest
+
+from flake8_picky_parentheses import PluginRedundantParentheses
 
 
 @pytest.fixture(params=[True, False])


### PR DESCRIPTION
After a closing bracket on a new line, only OPs (parens, brackets, operators,
...) and comments should follow.